### PR TITLE
Take into account a final `:`.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
     - name: setup StyLua
-      run: cargo install stylua
+      run: cargo install --version 0.8.1 stylua
     - name: run StyLua
       run: make format-check


### PR DESCRIPTION
When passing in the follwing:
`org.scalameta:metals_2.12:`
the coursier completion will still think that you're at the artifact
stage and try to complete this. This is incorrect since the final `:`
is obviously indicating we want the versions. This change also
grabs that info and will correctly set the stage to VERSION if two
`:` are found with a valid org and artifact.